### PR TITLE
Remove requiresAPI(S) from PublicKeyResponse

### DIFF
--- a/seedvault/src/main/java/com/solanamobile/seedvault/PublicKeyResponse.java
+++ b/seedvault/src/main/java/com/solanamobile/seedvault/PublicKeyResponse.java
@@ -5,13 +5,11 @@
 package com.solanamobile.seedvault;
 
 import android.net.Uri;
-import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -22,7 +20,6 @@ import java.util.Objects;
  *
  * @version 0.2
  */
-@RequiresApi(api = Build.VERSION_CODES.S) // library minSdk is 17; mark the actual requirements for this class
 public class PublicKeyResponse implements Parcelable {
     /**
      * This exception indicates that an account does not exist for this
@@ -72,14 +69,14 @@ public class PublicKeyResponse implements Parcelable {
     protected PublicKeyResponse(Parcel in) {
         mPublicKey = in.createByteArray();
         mPublicKeyEncoded = in.readString();
-        resolvedDerivationPath = in.readTypedObject(Uri.CREATOR);
+        resolvedDerivationPath = in.readParcelable(Uri.class.getClassLoader());
     }
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeByteArray(mPublicKey);
         dest.writeString(mPublicKeyEncoded);
-        dest.writeTypedObject(resolvedDerivationPath, 0);
+        dest.writeParcelable(resolvedDerivationPath, 0);
     }
 
     @Override


### PR DESCRIPTION
This API requirement is a bit too high—we can read and write from the parcel with a lower level API without `RequiresAPI(S)`.

While I don't know the exact API level that Saga will launch on, this will make it a bit easier to work with the simulated seed vault