### PR TITLE
Fix a crash when launching SeedVaultImpl for a Content Provider call

### DIFF
--- a/impl/src/main/java/com/solanamobile/seedvaultimpl/SeedVaultImplApplication.kt
+++ b/impl/src/main/java/com/solanamobile/seedvaultimpl/SeedVaultImplApplication.kt
@@ -11,10 +11,7 @@ import kotlinx.coroutines.SupervisorJob
 
 class SeedVaultImplApplication : Application() {
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    lateinit var dependencyContainer: ApplicationDependencyContainer
-
-    override fun onCreate() {
-        super.onCreate()
-        dependencyContainer = ApplicationDependencyContainer(this, applicationScope)
+    val dependencyContainer: ApplicationDependencyContainer by lazy {
+        ApplicationDependencyContainer(this, applicationScope)
     }
 }


### PR DESCRIPTION
Fixes #82
When launching SeedVaultImpl due to a Content Provider call, the onCreate method
of the Application object may not yet have been invoked, and the dependency
container would thus be uninitialized. Instead, use a Kotlin lazy initializer to
create the dependency container.