### PR TITLE
Fix: fix native module when seed vault not available

### DIFF
--- a/js/packages/seed-vault/android/src/main/java/com/solanamobile/seedvault/reactnative/SolanaMobileSeedVaultLibModule.kt
+++ b/js/packages/seed-vault/android/src/main/java/com/solanamobile/seedvault/reactnative/SolanaMobileSeedVaultLibModule.kt
@@ -43,7 +43,9 @@ class SolanaMobileSeedVaultLibModule(val reactContext: ReactApplicationContext) 
     init {
         reactContext.addActivityEventListener(mActivityEventListener)
 
-        observeSeedVaultContentChanges()
+        if (SeedVault.isAvailable(reactContext, true)) {
+            observeSeedVaultContentChanges()
+        }
     }
 
     @ReactMethod

--- a/js/packages/seed-vault/src/types.ts
+++ b/js/packages/seed-vault/src/types.ts
@@ -81,11 +81,16 @@ interface SignTransactionsAPI {
     signTransactions(authToken: AuthToken, signingRequests: SigningRequest[]): SigningResult[]
 }
 
+interface SeedVaultAvailabilityAPI {
+    isSeedVaultAvailable(allowSimulated: boolean): boolean
+}
+
 export interface SeedVaultAPI 
     extends AuthorizeSeedAPI,
         AccountAPI,
         CreateNewSeedAPI,
         ImportExistingSeedAPI,
         PublicKeyAPI,
+        SeedVaultAvailabilityAPI,
         SignMessagesAPI, 
         SignTransactionsAPI {}


### PR DESCRIPTION
- fixes the native module throwing an error if seed vault is not available
- exposed the `isSeedVaultAvailable()` method in the `SeedVaultAPI`
- corresponding example app changes in another pr

testing: installed the example app on an emulator that does not have seedvault, ensured that the app does not crash in this case. 