### PR TITLE
Disables package data backup/restore from seedvaultwallet and fakewallet

### DIFF
--- a/SeedVaultSimulator/src/main/AndroidManifest.xml
+++ b/SeedVaultSimulator/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
 
     <application
         android:name=".SeedVaultImplApplication"
+        android:allowBackup="false"
         android:icon="${appIcon}"
         android:label="@string/app_name"
         android:roundIcon="${appIconRound}"

--- a/fakewallet/src/main/AndroidManifest.xml
+++ b/fakewallet/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:name="com.solanamobile.seedvault.ACCESS_SEED_VAULT" />
 
     <application
+        android:allowBackup="false"
         android:icon="${appIcon}"
         android:label="@string/app_name"
         android:roundIcon="${appIconRound}"


### PR DESCRIPTION
This change blocks backup/restore of package data from Seed Vault Simulator and FakeWallet on test devices with signed-in Google account.