### PR TITLE
chore(dependabot): group minor/patch updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,26 @@ updates:
     schedule:
       interval: "weekly"
 
+    # One grouped PR for minor + patch bumps; majors land individually.
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "gradle"
     # Files stored in the default project in the root of this repo
     directories:
       - "/"
     schedule:
       interval: "weekly"
+
+    # One grouped PR for minor + patch bumps; majors land individually.
+    groups:
+      gradle:
+        update-types:
+          - "minor"
+          - "patch"
 
   # DISABLED UNTIL js/ IS SUPPORTED
   #- package-ecosystem: "npm"


### PR DESCRIPTION
Adds a minor+patch group to each ecosystem entry so routine bumps land in one PR instead of one-per-dependency. Major version bumps still open individually. Existing structure and any pre-existing groups left untouched.

Follow-up to the org-wide dependabot open-PR audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)