### PR TITLE
Run CTS instrumentation tests on Genymotion Cloud SaaS

### DIFF
--- a/.github/scripts/run-cts-tests.sh
+++ b/.github/scripts/run-cts-tests.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Drives :cts instrumentation corpus against adb device.
+# Used by .github/workflows/android.yml.
+#
+#   ANDROID_SERIAL=<serial> bash .github/scripts/run-cts-tests.sh
+#
+set -euo pipefail
+
+REPORT_DIR=cts/build/reports/androidTests/connected
+mkdir -p "$REPORT_DIR"
+
+##############################################################################
+# Device readiness and determinism
+#
+# reactivecircus/android-emulator-runner already does some of this itself
+# but still needed for local or remote Genymotion devices.
+##############################################################################
+
+echo "adb devices:"
+adb devices -l
+
+# Wait 2 minutes for remote device discovery, then fail job
+DEADLINE=$((SECONDS + 120))
+until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; do
+    if (( SECONDS > DEADLINE )); then
+        echo "device ${ANDROID_SERIAL:-<none>} not ready after 120s" >&2
+        adb devices -l >&2
+        exit 1
+    fi
+    sleep 2
+done
+echo "device ready after $((SECONDS - DEADLINE + 120))s"
+
+# Keep the screen awake for the whole run. If it sleeps between passes the device re-locks and the
+# keyguard covers the app, so UiAutomator sees only SystemUI.
+adb shell svc power stayon true
+adb shell wm dismiss-keyguard || true
+adb shell settings put global window_animation_scale 0.0
+adb shell settings put global transition_animation_scale 0.0
+adb shell settings put global animator_duration_scale 0.0
+
+# Both CTS flavors share an applicationId but are signed with different keys, so a leftover install
+# from an interrupted run fails the next one with INSTALL_FAILED_UPDATE_INCOMPATIBLE. Never happens
+# on a freshly provisioned CI device; matters when re-running against a persistent local device.
+adb uninstall com.solanamobile.seedvault.cts > /dev/null 2>&1 || true
+adb uninstall com.solanamobile.seedvault.cts.test > /dev/null 2>&1 || true
+
+##############################################################################
+# Logcat capture (uploaded as a workflow artifact alongside the test reports)
+##############################################################################
+
+adb logcat -c
+adb logcat >> "$REPORT_DIR/instrumented_tests_logcat.txt" &
+trap 'kill %1 2>/dev/null || true' EXIT
+
+##############################################################################
+# Test
+#
+# Ordering is load-bearing: SeedVaultSimulatorSetup wipes simulator seed state
+# before each RunCtsTestsOnSimulator pass.
+##############################################################################
+
+run_pass() {
+  local label=$1 start=$SECONDS
+  shift
+  echo "::group::$label"
+  adb shell wm dismiss-keyguard || true
+  "$@"
+  echo "::endgroup::"
+  echo "$label took $((SECONDS - start))s"
+}
+
+run_pass "install SeedVaultSimulator" ./gradlew :SeedVaultSimulator:installDebug
+
+for FLAVOR in Generic Privileged; do
+  for CLASS in SeedVaultSimulatorSetup RunCtsTestsOnSimulator; do
+    run_pass "$FLAVOR / $CLASS" ./gradlew ":cts:connected${FLAVOR}DebugAndroidTest" \
+      "-Pandroid.testInstrumentationRunnerArguments.class=com.solanamobile.seedvault.cts.${CLASS}"
+  done
+done

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,15 +10,28 @@ on:
   release:
     types: [ published ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
+  # Local emulator config as fallback when Genymotion API token is unavailable
   AVD_ANDROID_API_LEVEL: '35'
   AVD_ANDROID_ARCH: 'x86_64'
   AVD_ANDROID_TARGET: 'google_atd'
+  # Genymotion Cloud SaaS recipe: Android 15 / API 35, 1200x2670 @460dpi, arm64
+  GENYMOTION_RECIPE_UUID: '24be9f8e-535c-49d1-9aaf-ed7e66687361'
+  # Must stay outside adb's emulator discovery range (5555-5585), or adb adopts the instance as an
+  # emulator and renames it emulator-<port-1>, leaving localhost:<port> offline and unusable.
+  GENYMOTION_ADB_PORT: '6555'
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Fork PRs cannot read repository secrets, and fall back to local emulator.
+      USE_GENYMOTION: ${{ secrets.GMSAAS_API_KEY != '' && 'true' || 'false' }}
 
     steps:
       ##########################################################################
@@ -30,6 +43,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Enable KVM for Android Virtual Device acceleration
+        if: env.USE_GENYMOTION != 'true'
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
@@ -41,10 +55,16 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          packages: '' # runner image already ships platform-tools
+
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v6
 
       - name: AVD cache
+        if: env.USE_GENYMOTION != 'true'
         uses: actions/cache@v6
         id: avd-cache
         with:
@@ -55,7 +75,7 @@ jobs:
 
       # NOTE: Keep AVD snapshot generation option in sync with the AVD test execution step below
       - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
+        if: env.USE_GENYMOTION != 'true' && steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.AVD_ANDROID_API_LEVEL }}
@@ -102,7 +122,24 @@ jobs:
       # Test
       ##########################################################################
 
-      - name: run CTS test automation
+      - name: Start Genymotion Cloud SaaS device
+        id: genymotion
+        if: env.USE_GENYMOTION == 'true'
+        uses: genymobile/genymotion-saas-github-action@v1
+        with:
+          api_token: ${{ secrets.GMSAAS_API_KEY }}
+          recipe_uuid: ${{ env.GENYMOTION_RECIPE_UUID }}
+          adb_serial_port: ${{ env.GENYMOTION_ADB_PORT }}
+
+      - name: run CTS test automation on remote device
+        if: env.USE_GENYMOTION == 'true'
+        env:
+          ANDROID_SERIAL: localhost:${{ env.GENYMOTION_ADB_PORT }}
+        run: bash .github/scripts/run-cts-tests.sh
+
+      # Fallback for forks without secrets.GMSAAS_API_KEY set
+      - name: run CTS test automation on local emulator
+        if: env.USE_GENYMOTION != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.AVD_ANDROID_API_LEVEL }}
@@ -113,15 +150,7 @@ jobs:
           emulator-boot-timeout: 120 # 2 minutes. Fail fast.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: |
-            adb logcat -c
-            mkdir -p cts/build/reports/androidTests/connected
-            adb logcat >> cts/build/reports/androidTests/connected/instrumented_tests_logcat.txt & 
-            ./gradlew :SeedVaultSimulator:installDebug
-            ./gradlew :cts:connectedGenericDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.solanamobile.seedvault.cts.SeedVaultSimulatorSetup
-            ./gradlew :cts:connectedGenericDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.solanamobile.seedvault.cts.RunCtsTestsOnSimulator
-            ./gradlew :cts:connectedPrivilegedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.solanamobile.seedvault.cts.SeedVaultSimulatorSetup
-            ./gradlew :cts:connectedPrivilegedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.solanamobile.seedvault.cts.RunCtsTestsOnSimulator
+          script: bash .github/scripts/run-cts-tests.sh
 
       ##########################################################################
       # Upload test artifacts

--- a/SeedVaultSimulator/build.gradle
+++ b/SeedVaultSimulator/build.gradle
@@ -65,6 +65,10 @@ android {
         compose true
         viewBinding true
     }
+
+    installation {
+        timeOutInMs = 600000 // CI installs might go over remote adb
+    }
 }
 
 protobuf {

--- a/SeedVaultSimulator/src/main/java/com/solanamobile/seedvaultimpl/ui/authorize/AuthorizeContents.kt
+++ b/SeedVaultSimulator/src/main/java/com/solanamobile/seedvaultimpl/ui/authorize/AuthorizeContents.kt
@@ -525,6 +525,12 @@ fun NonPrivilegedAuthorizeContents(
                     }
                 }
             }
+
+            // The sheet drops its bottom inset (see contentWindowInsets above), so without this the
+            // button row lands under the navigation bar and cannot be tapped.
+            Box(
+                modifier = Modifier.navigationBarsPadding(),
+            )
         }
     }
 }

--- a/cts/build.gradle
+++ b/cts/build.gradle
@@ -76,6 +76,9 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    installation {
+        timeOutInMs = 600000 // CI installs might go over remote adb
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The GitHub-hosted AVD has been the main source of CI flakiness. Move the device to a Genymotion Cloud SaaS instance (Android 15 / API 35, arm64) reached over remote adb, while the build stays on the GitHub runner.

Fork PRs cannot read repository secrets, so they keep using the local emulator. Both paths drive the same test sequence through one script.

Note to self: `GMSAAS_API_KEY` needed as dependabot secret for bump PR coverage.